### PR TITLE
feat(timezones): Add UTC to list of timezones

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,10 @@ interface TimeZone extends RawTimeZone {
   currentTimeFormat: string;
 }
 
+interface TimeZoneOptions {
+  includeUtc?: boolean;
+}
+
 export const rawTimeZones: RawTimeZone[];
 export const timeZonesNames: TimeZoneName[];
-export function getTimeZones(): TimeZone[];
+export function getTimeZones(opts?: TimeZoneOptions): TimeZone[];

--- a/lib/getTimeZones.js
+++ b/lib/getTimeZones.js
@@ -7,34 +7,37 @@ import formatTimeZone from "./formatTimeZone.js";
 export default function getTimeZones(opts) {
   const includeUtc = !!opts && opts.includeUtc;
   return rawTimeZones
-    .reduce(function (acc, timeZone) {
-      const currentDate = DateTime.fromObject({
-        locale: "en-US",
-        zone: timeZone.name,
-      });
+    .reduce(
+      function (acc, timeZone) {
+        const currentDate = DateTime.fromObject({
+          locale: "en-US",
+          zone: timeZone.name,
+        });
 
-      // We build on the latest Node.js version, Node.js embed IANA databases
-      // it might happen that the environment that will execute getTimeZones() will not know about some
-      // timezones. So we ignore the timezone at runtim
-      // See https://github.com/vvo/tzdb/issues/43
-      if (currentDate.isValid === false) {
+        // We build on the latest Node.js version, Node.js embed IANA databases
+        // it might happen that the environment that will execute getTimeZones() will not know about some
+        // timezones. So we ignore the timezone at runtim
+        // See https://github.com/vvo/tzdb/issues/43
+        if (currentDate.isValid === false) {
+          return acc;
+        }
+
+        const timeZoneWithCurrentTimeData = {
+          ...timeZone,
+          currentTimeOffsetInMinutes: currentDate.offset,
+        };
+
+        acc.push({
+          ...timeZoneWithCurrentTimeData,
+          currentTimeFormat: formatTimeZone(timeZoneWithCurrentTimeData, {
+            useCurrentOffset: true,
+          }),
+        });
+
         return acc;
-      }
-
-      const timeZoneWithCurrentTimeData = {
-        ...timeZone,
-        currentTimeOffsetInMinutes: currentDate.offset,
-      };
-
-      acc.push({
-        ...timeZoneWithCurrentTimeData,
-        currentTimeFormat: formatTimeZone(timeZoneWithCurrentTimeData, {
-          useCurrentOffset: true,
-        }),
-      });
-
-      return acc;
-    }, includeUtc ? [utcTimezone] : [])
+      },
+      includeUtc ? [utcTimezone] : [],
+    )
     .sort((a, b) => {
       return (
         compareNumbers(a, b) ||

--- a/lib/getTimeZones.js
+++ b/lib/getTimeZones.js
@@ -4,7 +4,8 @@ import rawTimeZones from "../raw-time-zones.json";
 
 import formatTimeZone from "./formatTimeZone.js";
 
-export default function getTimeZones() {
+export default function getTimeZones(opts) {
+  const includeUtc = !!opts && opts.includeUtc;
   return rawTimeZones
     .reduce(function (acc, timeZone) {
       const currentDate = DateTime.fromObject({
@@ -33,7 +34,7 @@ export default function getTimeZones() {
       });
 
       return acc;
-    }, [])
+    }, includeUtc ? [utcTimezone] : [])
     .sort((a, b) => {
       return (
         compareNumbers(a, b) ||
@@ -53,3 +54,18 @@ function compareStrings(x, y) {
   }
   return 0;
 }
+
+const utcTimezone = {
+  name: "UTC",
+  alternativeName: "Coordinated Universal Time (UTC)",
+  abbreviation: "UTC",
+  group: ["UTC"],
+  countryName: "",
+  continentCode: "",
+  continentName: "",
+  mainCities: [""],
+  rawOffsetInMinutes: 0,
+  rawFormat: "+00:00 Coordinated Universal Time (UTC)",
+  currentTimeOffsetInMinutes: 0,
+  currentTimeFormat: "+00:00 Coordinated Universal Time (UTC)",
+};


### PR DESCRIPTION
Implemented an `includeUtc` flag for the `getTimeZones` function. This flag will add a UTC timezone to the list of timezones retrieved by the `getTimeZones` function. It should be completely backwards compatible with older versions of this library.

I have purposefully left my code un-formatted to make the git diff easier to read. If you accept, I can run the format script to fix things.

Closes: #21 