### PR TITLE
refactor: remove luxon from prod dependencies

### DIFF
--- a/lib/formatTimeZone.js
+++ b/lib/formatTimeZone.js
@@ -1,5 +1,3 @@
-import { Duration } from "luxon";
-
 export default function format(
   {
     alternativeName,
@@ -20,9 +18,9 @@ export default function format(
 }
 
 function getOffsetString(offsetInMinutes) {
-  const durationInHoursMinutes = Duration.fromObject({
-    minutes: Math.abs(offsetInMinutes),
-  }).toFormat("hh:mm");
+  const absOffsetInMinutes = Math.abs(offsetInMinutes)
+  const [hours, minutes] = [Math.floor(absOffsetInMinutes / 60), absOffsetInMinutes % 60].map(v => v.toString().padStart(2, '0'))
+  const durationInHoursMinutes = `${hours}:${minutes}`
 
   return `${offsetInMinutes >= 0 ? "+" : "-"}${durationInHoursMinutes}`;
 }

--- a/lib/getTimeZones.js
+++ b/lib/getTimeZones.js
@@ -1,30 +1,27 @@
-import { DateTime } from "luxon";
-
 import rawTimeZones from "../raw-time-zones.json";
 
 import formatTimeZone from "./formatTimeZone.js";
+import {getZoneOffset} from "./utils/timeZone.js";
 
 export default function getTimeZones(opts) {
   const includeUtc = !!opts && opts.includeUtc;
   return rawTimeZones
     .reduce(
       function (acc, timeZone) {
-        const currentDate = DateTime.fromObject({
-          locale: "en-US",
-          zone: timeZone.name,
-        });
+        const timeZoneName = timeZone.name;
+        const currentOffset = getZoneOffset(timeZoneName);
 
         // We build on the latest Node.js version, Node.js embed IANA databases
         // it might happen that the environment that will execute getTimeZones() will not know about some
         // timezones. So we ignore the timezone at runtim
         // See https://github.com/vvo/tzdb/issues/43
-        if (currentDate.isValid === false) {
+        if (currentOffset === false) {
           return acc;
         }
 
         const timeZoneWithCurrentTimeData = {
           ...timeZone,
-          currentTimeOffsetInMinutes: currentDate.offset,
+          currentTimeOffsetInMinutes: currentOffset,
         };
 
         acc.push({

--- a/lib/utils/timeZone.js
+++ b/lib/utils/timeZone.js
@@ -1,0 +1,104 @@
+const ianaRegex = /^[A-Za-z_+-]{1,256}(:?\/[A-Za-z_+-]{1,256}(\/[A-Za-z_+-]{1,256})?)?$/;
+
+const typeToPos = {
+  year: 0,
+  month: 1,
+  day: 2,
+  hour: 3,
+  minute: 4,
+  second: 5,
+};
+
+function isValidIanaSpecifier(s) {
+  return !!(s && s.match(ianaRegex));
+}
+
+function hackyOffset(dtf, date) {
+  const formatted = dtf.format(date).replace(/\u200E/g, "");
+  const parsed = /(\d+)\/(\d+)\/(\d+),? (\d+):(\d+):(\d+)/.exec(formatted);
+  const [, fMonth, fDay, fYear, fHour, fMinute, fSecond] = parsed;
+  return [fYear, fMonth, fDay, fHour, fMinute, fSecond];
+}
+
+function partsOffset(dtf, date) {
+  const formatted = dtf.formatToParts(date);
+  const filled = [];
+  for (let i = 0; i < formatted.length; i++) {
+    const { type, value } = formatted[i];
+    const pos = typeToPos[type];
+
+    if (typeof pos !== 'undefined') {
+      filled[pos] = parseInt(value, 10);
+    }
+  }
+  return filled;
+}
+
+function makeDTF(zone) {
+  return new Intl.DateTimeFormat("en-US", {
+    hourCycle: "h23",
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+// covert a calendar object to a local timestamp (epoch, but with the offset baked in)
+function objToLocalTS(obj) {
+  let d = Date.UTC(
+    obj.year,
+    obj.month - 1,
+    obj.day,
+    obj.hour,
+    obj.minute,
+    obj.second,
+    obj.millisecond
+  );
+
+  // for legacy reasons, years between 0 and 99 are interpreted as 19XX; revert that
+  if (obj.year < 100 && obj.year >= 0) {
+    d = new Date(d);
+    d.setUTCFullYear(d.getUTCFullYear() - 1900);
+  }
+  return +d;
+}
+
+export function getZoneOffset(timeZoneName) {
+  if (!isValidIanaSpecifier(timeZoneName)) {
+    return false
+  }
+
+  const date = new Date(Date.now());
+
+  let dtf
+
+  try {
+    dtf = makeDTF(timeZoneName);
+  } catch(_) {
+    return false
+  }
+
+  const [year, month, day, hour, minute, second] = dtf.formatToParts
+      ? partsOffset(dtf, date)
+      : hackyOffset(dtf, date);
+
+  const asUTC = objToLocalTS({
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond: 0,
+  });
+
+  let asTS = +date;
+  const over = asTS % 1000;
+  asTS -= over >= 0 ? over : 1000 + over;
+  return (asUTC - asTS) / (60 * 1000);
+}
+

--- a/package.json
+++ b/package.json
@@ -90,9 +90,7 @@
       ]
     }
   },
-  "dependencies": {
-    "luxon": "1.26.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "7.13.16",
     "@babel/core": "7.14.8",
@@ -105,6 +103,7 @@
     "eslint-plugin-import": "2.24.1",
     "got": "11.8.2",
     "lodash": "4.17.21",
+    "luxon": "1.26.0",
     "prettier": "2.2.1",
     "prettier-plugin-packagejson": "2.2.11",
     "semantic-release": "17.4.5",


### PR DESCRIPTION
In my own project i've faced the problem when bundle had two versions of luxon (1.26 and 2). 1.26 came from this lib. Then i've found an open issue https://github.com/vvo/tzdb/issues/79 on the matter. So this PR's purpose is to remove luxon from production dependencies completely in favor of native Intl implementation.

I've checked how time zones are handled in `luxon` and decided not to reinvent the wheel. I've cloned some methods from it to get the same functionality, keep all the edge cases handled and avoid introducing new bugs. All cloned code is in `utils/timeZones.js`.