### PR TITLE
feat(timezones): Update UTC time zone object

### DIFF
--- a/lib/getTimeZones.js
+++ b/lib/getTimeZones.js
@@ -56,10 +56,10 @@ function compareStrings(x, y) {
 }
 
 const utcTimezone = {
-  name: "UTC",
+  name: "Etc/UTC",
   alternativeName: "Coordinated Universal Time (UTC)",
   abbreviation: "UTC",
-  group: ["UTC"],
+  group: ["Etc/UTC", "Etc/UCT", "UCT", "UTC", "Universal", "Zulu"],
   countryName: "",
   continentCode: "",
   continentName: "",


### PR DESCRIPTION
Currently, only `UTC` name is taken into the account.

This PR sets the name of the time zone to the Canonical `Etc\UTC` and adds backward compatible names to the `group` property as per [IANA list](https://data.iana.org/time-zones/data/backward).