### PR TITLE
Expose IANA time zone version

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/
 raw-time-zones.json
 time-zones-names.json
+metadata.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@
 /dist/
 time-zones-names.json
 raw-time-zones.json
+metadata.json

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm add @vvo/tzdb
 Usage:
 
 ```js
-import { getTimeZones, rawTimeZones, timeZonesNames, abbreviations } from "@vvo/tzdb";
+import { getTimeZones, rawTimeZones, timeZonesNames, abbreviations, metadata } from "@vvo/tzdb";
 ```
 
 ## API
@@ -166,6 +166,16 @@ This is an object mapping timezone abbreviations to their full forms:
 ```
 
 **Caution:** Although abbreviations can be easy to lookup, they can be misleading. For example: CST can refer to Central Standard Time (-06.00 UTC), China Standard Time (+06.00 UTC) or Cuba Standard Time (-05.00 UTC). And abbreviation full forms don't directly map to any property in the time zone objects returned by `rawTimeZones` or `getTimeZones()`.
+
+### metadata
+
+This is an object containing metadata about the package:
+
+```js
+{
+  ianaTzVersion: "2025b", // The IANA time zone database version
+}
+```
 
 ## Notes
 

--- a/generate.js
+++ b/generate.js
@@ -8,12 +8,12 @@ import unzipper from "unzipper";
 import got from "got";
 import { DateTime } from "luxon";
 import { orderBy, uniq } from "lodash";
-import tzdata from "tzdata";
+import { zones, version } from "tzdata";
 
 import abbreviations from "./abbreviations.json";
 import formatTimeZone from "./lib/formatTimeZone.js";
 
-const timeZonesLinks = Object.entries(tzdata.zones).filter(([, value]) => {
+const timeZonesLinks = Object.entries(zones).filter(([, value]) => {
   return typeof value === "string";
 });
 
@@ -311,6 +311,11 @@ async function run() {
         "mainCities[0]",
       ]),
     ).replace(/},/g, "},\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(__dirname, "metadata.json"),
+    JSON.stringify({ ianaTzVersion: version }),
   );
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,11 @@ interface TimeZoneOptions {
   includeUtc?: boolean;
 }
 
+interface Metadata {
+  ianaTzVersion: string;
+}
+
 export const rawTimeZones: RawTimeZone[];
 export const timeZonesNames: TimeZoneName[];
 export function getTimeZones(opts?: TimeZoneOptions): TimeZone[];
+export const metadata: Metadata;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,3 +2,4 @@ export { default as rawTimeZones } from "../raw-time-zones.json";
 export { default as timeZonesNames } from "../time-zones-names.json";
 export { default as getTimeZones } from "./getTimeZones.js";
 export { default as abbreviations } from "../abbreviations.json";
+export { default as metadata } from "../metadata.json";

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,1 @@
+{"ianaTzVersion":"2025b"}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "time-zones-names.json",
     "abbreviations.json",
     "raw-time-zones.json",
+    "metadata.json",
     "LICENSE",
     "README.md",
     "index.d.ts"
@@ -117,7 +118,7 @@
     "semantic-release": "18.0.1",
     "semantic-release-cli": "5.4.6",
     "sort-keys": "4.2.0",
-    "tzdata": "1.0.45",
+    "tzdata": "1.0.46",
     "unzipper": "0.12.3"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       tzdata:
-        specifier: 1.0.45
-        version: 1.0.45
+        specifier: 1.0.46
+        version: 1.0.46
       unzipper:
         specifier: 0.12.3
         version: 0.12.3
@@ -3726,8 +3726,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  tzdata@1.0.45:
-    resolution: {integrity: sha512-p5+G49/ilH5Olaotf41W5mw56ZvvaGIPjslqnu2VJQYeRrWpSy80pw110udPW3tyiLW8OWJzywABucaL1n0Kag==}
+  tzdata@1.0.46:
+    resolution: {integrity: sha512-zJ4Jv3KCgN3dFeSADpIfHKt9bdIY7TjK3ELaij6oFvyyQBuIZ9LwMlR51vJvMQvRWQ9cS2v92xeZ0sQW4hXCWA==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -7975,7 +7975,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  tzdata@1.0.45: {}
+  tzdata@1.0.46: {}
 
   uglify-js@3.19.3:
     optional: true


### PR DESCRIPTION
This PR addresses Issue #291 to expose the IANA time zone database version

- Update `tzdata` from `1.0.45` to `1.0.46`
  - I did a [PR to the tzdata package](https://github.com/rogierschouten/tzdata-generate/pull/18) to expose the IANA version there first
- During the generate script, writes a new `metadata.json` file containing the `ianaTzVersion`
- Export this metadata in `lib/index.js` for others to use
- Update types
- Update README

After running the script, I noticed a few warnings, though I don't think it's related to this change, since I was seeing these same warnings on the main branch:
<img width="616" height="125" alt="image" src="https://github.com/user-attachments/assets/7088be88-26ca-4c25-ab4f-b3d591579347" />
