### PR TITLE
fix: avoid appending empty cities suffix in formatTimeZone

### DIFF
--- a/lib/formatTimeZone.js
+++ b/lib/formatTimeZone.js
@@ -11,10 +11,15 @@ export default function format(
     ? getOffsetString(currentTimeOffsetInMinutes)
     : getOffsetString(rawOffsetInMinutes);
 
+  const citiesFormatted =
+    mainCities && mainCities.filter(Boolean).length > 0
+      ? ` - ${mainCities.join(", ")}`
+      : "";
+
   return `${offsetInHours.padStart(
     6,
     "+",
-  )} ${alternativeName} - ${mainCities.join(", ")}`;
+  )} ${alternativeName}${citiesFormatted}`;
 }
 
 function getOffsetString(offsetInMinutes) {


### PR DESCRIPTION
In formatTimeZone.js, if mainCities contains no non-empty elements or is empty, the formatter previously still appended a trailing ` - ` hyphen delimiter. This proposed fix checks if there are any valid non-empty city strings in mainCities and conditionally formats the suffix to ensure correct timezone representation formatting without trailing hyphens.